### PR TITLE
[SPRINT-M25] fix: resolve null duplicate issue for Admins (who do not have student id) in user_id (User collection)

### DIFF
--- a/backend/models/schema.js
+++ b/backend/models/schema.js
@@ -6,7 +6,6 @@ var findOrCreate = require("mongoose-findorcreate");
 const userSchema = new mongoose.Schema({
   user_id: {
     type: String,
-    unique: true,
     //user_id is the ID provided by institute, ie ID no
   },
   role: {
@@ -86,6 +85,16 @@ const userSchema = new mongoose.Schema({
     default: Date.now,
   },
 });
+
+userSchema.index(
+  { user_id: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { user_id: { $exists: true, $type: "string" } },
+    name: "user_id_partial_unique"
+  }
+);
+
 userSchema.plugin(passportLocalMongoose);
 userSchema.plugin(findOrCreate);
 


### PR DESCRIPTION
### What was fixed
- Fixed the null duplicate key error for admins logging in.
- The `user_id` field is only meant for students, but the previous full unique index caused conflicts when `user_id` was null (admin case).

### Changes made
1. Dropped the old full unique index on `user_id`.
2. Added a **partial unique index** that only applies to documents where `user_id` exists and is a string.
3. Updated the Mongoose schema index to match this partial unique index.
4. Removed `unique: true` from the `user_id` field in the schema since uniqueness is now enforced at the DB level.


### Code reference
```js
userSchema.index(
  { user_id: 1 },
  {
    unique: true,
    partialFilterExpression: { user_id: { $exists: true, $type: "string" } },
    name: "user_id_partial_unique"
  }
);
