### PR TITLE
Implemeted Role-Based-Scoping in Add Position Form

### DIFF
--- a/frontend/src/Components/Positions/AddPositionForm.jsx
+++ b/frontend/src/Components/Positions/AddPositionForm.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect, useRef } from "react";
+"use client";
+
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus, X, AlertCircle } from "lucide-react";
 import api from "../../utils/api";
-
-// --- STABLE HELPER COMPONENTS & CONSTANTS (MOVED OUTSIDE) ---
+import { useAdminContext } from "../../context/AdminContext";
 
 const initialFormState = {
   title: "",
@@ -20,59 +21,126 @@ const initialFormState = {
   position_count: 1,
 };
 
-const inputStyles = "w-full p-2 mt-1 bg-white border border-stone-300 rounded-lg text-sm text-stone-900 placeholder-stone-400 focus:ring-1 focus:ring-stone-400 focus:border-stone-400 transition";
+const inputStyles =
+  "w-full p-2 mt-1 bg-white border border-stone-300 rounded-lg text-sm text-stone-900 placeholder-stone-400 focus:ring-1 focus:ring-stone-400 focus:border-stone-400 transition";
 const labelStyles = "text-sm font-medium text-stone-600";
 
-const ErrorMessage = ({ message }) => message ? ( <div className="flex items-center mt-1 text-xs text-red-600"><AlertCircle className="w-4 h-4 mr-1 flex-shrink-0" />{message}</div>) : null;
-  
-const DynamicFieldArray = ({ label, array, onUpdate, onRemove, onAdd, error }) => (
-    <div>
-        <label className={labelStyles}>{label} <span className="text-red-500">*</span></label>
-        {array.map((item, index) => (
-            <div key={index} className="flex items-center gap-2 mt-1">
-                <input type="text" value={item} onChange={(e) => onUpdate(index, e.target.value)} className={inputStyles + " !mt-0 flex-grow"} placeholder={`${label.slice(0,-1)} #${index + 1}`} />
-                {array.length > 1 && (
-                    <button type="button" onClick={() => onRemove(index)} className="p-2 text-stone-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors">
-                        <X size={16} />
-                    </button>
-                )}
-            </div>
-        ))}
-        <button type="button" onClick={onAdd} className="text-stone-600 hover:text-stone-800 font-medium text-sm mt-2 transition flex items-center gap-1">
-            <Plus size={14} /> Add {label.slice(0,-1)}
-        </button>
-        <ErrorMessage message={error} />
+const ErrorMessage = ({ message }) =>
+  message ? (
+    <div className="flex items-center mt-1 text-xs text-red-600">
+      <AlertCircle className="w-4 h-4 mr-1 flex-shrink-0" />
+      {message}
     </div>
+  ) : null;
+
+const DynamicFieldArray = ({
+  label,
+  array,
+  onUpdate,
+  onRemove,
+  onAdd,
+  error,
+}) => (
+  <div>
+    <label className={labelStyles}>
+      {label} <span className="text-red-500">*</span>
+    </label>
+    {array.map((item, index) => (
+      <div key={index} className="flex items-center gap-2 mt-1">
+        <input
+          type="text"
+          value={item}
+          onChange={(e) => onUpdate(index, e.target.value)}
+          className={inputStyles + " !mt-0 flex-grow"}
+          placeholder={`${label.slice(0, -1)} #${index + 1}`}
+        />
+        {array.length > 1 && (
+          <button
+            type="button"
+            onClick={() => onRemove(index)}
+            className="p-2 text-stone-400 hover:text-red-500 rounded-full hover:bg-red-50 transition-colors"
+          >
+            <X size={16} />
+          </button>
+        )}
+      </div>
+    ))}
+    <button
+      type="button"
+      onClick={onAdd}
+      className="text-stone-600 hover:text-stone-800 font-medium text-sm mt-2 transition flex items-center gap-1"
+    >
+      <Plus size={14} /> Add {label.slice(0, -1)}
+    </button>
+    <ErrorMessage message={error} />
+  </div>
 );
 
-// --- MAIN COMPONENT ---
-
-const AddPositionForm = () => {
+const AddPositionForm = (props) => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState(initialFormState);
 
   const [units, setUnits] = useState([]);
+  const [scopedUnits, setScopedUnits] = useState([]);
+  const [isCoordinator, setIsCoordinator] = useState(false);
+
   const [unitSearchTerm, setUnitSearchTerm] = useState("");
   const [isUnitDropdownOpen, setIsUnitDropdownOpen] = useState(false);
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const unitDropdownRef = useRef(null);
 
+  const currentUser = useAdminContext();
+  const ctxUser = currentUser?.currentUser || currentUser;
+  const [userRole, setUserRole] = useState("");
+  const [userEmail, setUserEmail] = useState("");
+  useEffect(() => {
+    setUserRole(ctxUser?.role || props?.userRole || "");
+    setUserEmail(ctxUser?.email || props?.userEmail || "");
+  }, [ctxUser?.role, ctxUser?.email, props?.userRole, props?.userEmail]);
+
+  const positionTypes = [
+    "Core Member",
+    "Member",
+    "Team Lead",
+    "Coordinator",
+    "Volunteer",
+    "Intern",
+    "Other",
+  ];
+  const yearOptions = [
+    { value: 1, label: "1st Year" },
+    { value: 2, label: "2nd Year" },
+    { value: 3, label: "3rd Year" },
+    { value: 4, label: "4th Year" },
+  ];
+
+  const gensecRoleToCategory = (role) => {
+    if (!role || !role.startsWith("GENSEC")) return null;
+    const part = role.split("_")[1]?.toLowerCase();
+    if (["scitech", "academic", "cultural", "sports"].includes(part))
+      return part;
+    return null;
+  };
+
   useEffect(() => {
     const fetchUnits = async () => {
       try {
         const res = await api.get(`/api/events/units`);
-        setUnits(res.data);
+        setUnits(res.data || []);
       } catch (error) {
-        console.error("Failed to fetch organizational units:", error);
+        console.error("[v0] Failed to fetch organizational units:", error);
       }
     };
     fetchUnits();
   }, []);
-  
+
   useEffect(() => {
     const handleClickOutside = (event) => {
-      if (unitDropdownRef.current && !unitDropdownRef.current.contains(event.target)) {
+      if (
+        unitDropdownRef.current &&
+        !unitDropdownRef.current.contains(event.target)
+      ) {
         setIsUnitDropdownOpen(false);
       }
     };
@@ -82,64 +150,136 @@ const AddPositionForm = () => {
     };
   }, []);
 
-  const positionTypes = ["Core Member", "Member", "Team Lead", "Coordinator", "Volunteer", "Intern", "Other"];
-  const yearOptions = [{ value: 1, label: "1st Year" }, { value: 2, label: "2nd Year" }, { value: 3, label: "3rd Year" }, { value: 4, label: "4th Year" }];
+  useEffect(() => {
+    if (!Array.isArray(units) || units.length === 0) {
+      setScopedUnits([]);
+      setIsCoordinator(false);
+      return;
+    }
 
-  const filteredUnits = units.filter((unit) =>
-    unit.name.toLowerCase().includes(unitSearchTerm.toLowerCase())
-  );
+    // PRESIDENT: all units
+    if (userRole === "PRESIDENT") {
+      setScopedUnits(units);
+      setIsCoordinator(false);
+      return;
+    }
+
+    // GENSEC_*: category-based scope
+    const cat = gensecRoleToCategory(userRole);
+    if (cat) {
+      const scoped = units.filter(
+        (u) => (u?.category || "").toLowerCase() === cat,
+      );
+      setScopedUnits(scoped);
+      setIsCoordinator(false);
+      return;
+    }
+
+    // CLUB_COORDINATOR: only their club (match by contact_info.email)
+    if (userRole === "CLUB_COORDINATOR" && userEmail) {
+      const coordinatorUnit = units.find(
+        (u) =>
+          u?.contact_info?.email &&
+          u.contact_info.email.toLowerCase() === userEmail.toLowerCase(),
+      );
+      if (coordinatorUnit) {
+        setScopedUnits([coordinatorUnit]);
+        setFormData((prev) => ({ ...prev, unit_id: coordinatorUnit._id }));
+      } else {
+        setScopedUnits([]);
+      }
+      setIsCoordinator(true);
+      return;
+    }
+
+    // Default: no special restriction
+    setScopedUnits(units);
+    setIsCoordinator(false);
+  }, [units, userRole, userEmail]);
+
+  const filteredUnits = isCoordinator
+    ? scopedUnits
+    : scopedUnits.filter((unit) =>
+        (unit?.name || "").toLowerCase().includes(unitSearchTerm.toLowerCase()),
+      );
 
   const validateForm = () => {
     const newErrors = {};
     if (!formData.title.trim()) newErrors.title = "Position title is required.";
-    if (!formData.unit_id) newErrors.unit_id = "Organizational unit is required.";
-    if (!formData.position_type) newErrors.position_type = "Position type is required.";
-    if (formData.position_type === "Other" && !formData.custom_position_type.trim()) newErrors.custom_position_type = "Please specify the position type.";
-    if (formData.responsibilities.every(r => r.trim() === "")) newErrors.responsibilities = "At least one responsibility is required.";
-    if (!formData.position_count || formData.position_count < 1) newErrors.position_count = "Position count must be at least 1.";
+    if (!formData.unit_id)
+      newErrors.unit_id = "Organizational unit is required.";
+    if (!formData.position_type)
+      newErrors.position_type = "Position type is required.";
+    if (
+      formData.position_type === "Other" &&
+      !formData.custom_position_type.trim()
+    )
+      newErrors.custom_position_type = "Please specify the position type.";
+    if (formData.responsibilities.every((r) => r.trim() === ""))
+      newErrors.responsibilities = "At least one responsibility is required.";
+    if (!formData.position_count || formData.position_count < 1)
+      newErrors.position_count = "Position count must be at least 1.";
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
-  
+
   const handleInputChange = (field, value) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) setErrors(prev => ({ ...prev, [field]: "" }));
+    if (errors[field]) setErrors((prev) => ({ ...prev, [field]: "" }));
   };
 
   const handleRequirementChange = (field, value) => {
-    setFormData((prev) => ({ ...prev, requirements: { ...prev.requirements, [field]: value }}));
+    setFormData((prev) => ({
+      ...prev,
+      requirements: { ...prev.requirements, [field]: value },
+    }));
   };
 
   const handleArrayChange = (arrayName, index, value) => {
-    setFormData(prev => {
-        const updatedArray = [...prev[arrayName]];
-        updatedArray[index] = value;
-        return { ...prev, [arrayName]: updatedArray };
+    setFormData((prev) => {
+      const updatedArray = [...prev[arrayName]];
+      updatedArray[index] = value;
+      return { ...prev, [arrayName]: updatedArray };
     });
   };
 
   const addToArray = (arrayName) => {
-    setFormData(prev => ({ ...prev, [arrayName]: [...prev[arrayName], ""] }));
+    setFormData((prev) => ({
+      ...prev,
+      [arrayName]: [...prev[arrayName], ""],
+    }));
   };
 
   const removeFromArray = (arrayName, index) => {
-    setFormData(prev => ({ ...prev, [arrayName]: prev[arrayName].filter((_, i) => i !== index) }));
+    setFormData((prev) => ({
+      ...prev,
+      [arrayName]: prev[arrayName].filter((_, i) => i !== index),
+    }));
   };
 
   const handleSkillsChange = (index, value) => {
-    setFormData(prev => {
-        const updatedSkills = [...prev.requirements.skills_required];
-        updatedSkills[index] = value;
-        return { ...prev, requirements: { ...prev.requirements, skills_required: updatedSkills }};
+    setFormData((prev) => {
+      const updatedSkills = [...prev.requirements.skills_required];
+      updatedSkills[index] = value;
+      return {
+        ...prev,
+        requirements: { ...prev.requirements, skills_required: updatedSkills },
+      };
     });
   };
-  
+
   const addSkill = () => {
-    handleRequirementChange("skills_required", [...formData.requirements.skills_required, ""]);
+    handleRequirementChange("skills_required", [
+      ...formData.requirements.skills_required,
+      "",
+    ]);
   };
-  
+
   const removeSkill = (index) => {
-    handleRequirementChange("skills_required", formData.requirements.skills_required.filter((_, i) => i !== index));
+    handleRequirementChange(
+      "skills_required",
+      formData.requirements.skills_required.filter((_, i) => i !== index),
+    );
   };
 
   const handleSubmit = async (e) => {
@@ -149,11 +289,16 @@ const AddPositionForm = () => {
     setIsSubmitting(true);
     const cleanedData = {
       ...formData,
-      position_type: formData.position_type === "Other" ? formData.custom_position_type : formData.position_type,
+      position_type:
+        formData.position_type === "Other"
+          ? formData.custom_position_type
+          : formData.position_type,
       responsibilities: formData.responsibilities.filter((r) => r.trim()),
       requirements: {
         ...formData.requirements,
-        skills_required: formData.requirements.skills_required.filter((s) => s.trim()),
+        skills_required: formData.requirements.skills_required.filter((s) =>
+          s.trim(),
+        ),
       },
     };
 
@@ -165,7 +310,7 @@ const AddPositionForm = () => {
     } catch (error) {
       alert(error.response?.data?.message || "Failed to create position.");
     } finally {
-        setIsSubmitting(false);
+      setIsSubmitting(false);
     }
   };
 
@@ -173,87 +318,241 @@ const AddPositionForm = () => {
 
   return (
     <div className="min-h-screen w-full bg-[#FDFAE2] flex items-center justify-center p-4 font-sans">
-      <form onSubmit={handleSubmit} className="w-full max-w-3xl p-8 bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg border border-stone-200 space-y-6">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-3xl p-8 bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg border border-stone-200 space-y-6"
+      >
         <div className="text-center">
-          <h2 className="text-2xl font-bold text-stone-800">Add New Position</h2>
-          <p className="text-stone-500 mt-1 text-sm">Define a new role within an organizational unit.</p>
+          <h2 className="text-2xl font-bold text-stone-800">
+            Add New Position
+          </h2>
+          <p className="text-stone-500 mt-1 text-sm">
+            Define a new role within an organizational unit.
+          </p>
         </div>
 
         {/* Section 1: Basic Information */}
         <div className="pt-4 border-t border-stone-200">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <label className={labelStyles}>Position Title <span className="text-red-500">*</span></label>
-                    <input type="text" value={formData.title} onChange={(e) => handleInputChange("title", e.target.value)} placeholder="e.g., Core Member" className={inputStyles} />
-                    <ErrorMessage message={errors.title} />
-                </div>
-                <div ref={unitDropdownRef} className="relative">
-                    <label className={labelStyles}>Organizational Unit <span className="text-red-500">*</span></label>
-                    <input type="text" value={selectedUnit ? selectedUnit.name : unitSearchTerm} onChange={(e) => { setUnitSearchTerm(e.target.value); setIsUnitDropdownOpen(true); if (!e.target.value) handleInputChange("unit_id", ""); }} onFocus={() => setIsUnitDropdownOpen(true)} placeholder="Search for unit" className={inputStyles} />
-                    {isUnitDropdownOpen && (
-                        <div className="absolute z-20 w-full mt-1 bg-white border border-stone-300 rounded-lg shadow-lg max-h-48 overflow-y-auto">
-                            {filteredUnits.length > 0 ? filteredUnits.map((unit) => (
-                                <div key={unit._id} onClick={() => { handleInputChange("unit_id", unit._id); setUnitSearchTerm(""); setIsUnitDropdownOpen(false); }} className="px-3 py-2 text-sm hover:bg-stone-100 cursor-pointer">{unit.name}</div>
-                            )) : <div className="px-3 py-2 text-sm text-stone-500">No units found.</div>}
-                        </div>
-                    )}
-                    <ErrorMessage message={errors.unit_id} />
-                </div>
-                <div>
-                    <label className={labelStyles}>Position Type <span className="text-red-500">*</span></label>
-                    <select value={formData.position_type} onChange={(e) => handleInputChange("position_type", e.target.value)} className={inputStyles}>
-                        <option value="">Select type</option>
-                        {positionTypes.map((type) => (<option key={type} value={type}>{type}</option>))}
-                    </select>
-                    <ErrorMessage message={errors.position_type} />
-                </div>
-                {formData.position_type === "Other" && (
-                    <div>
-                        <label className={labelStyles}>Custom Type <span className="text-red-500">*</span></label>
-                        <input type="text" value={formData.custom_position_type} onChange={(e) => handleInputChange("custom_position_type", e.target.value)} placeholder="e.g., Research Assistant" className={inputStyles} />
-                        <ErrorMessage message={errors.custom_position_type} />
-                    </div>
-                )}
-                 <div>
-                    <label className={labelStyles}>Number of Positions <span className="text-red-500">*</span></label>
-                    <input type="number" min="1" value={formData.position_count} onChange={(e) => handleInputChange("position_count", Number(e.target.value))} className={inputStyles} />
-                    <ErrorMessage message={errors.position_count} />
-                </div>
-                <div className="md:col-span-2">
-                    <label className={labelStyles}>Description</label>
-                    <textarea value={formData.description} onChange={(e) => handleInputChange("description", e.target.value)} placeholder="Provide a detailed description of the position..." rows={3} className={inputStyles} />
-                </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className={labelStyles}>
+                Position Title <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData.title}
+                onChange={(e) => handleInputChange("title", e.target.value)}
+                placeholder="e.g., Core Member"
+                className={inputStyles}
+              />
+              <ErrorMessage message={errors.title} />
             </div>
+
+            <div ref={unitDropdownRef} className="relative">
+              <label className={labelStyles}>
+                Organizational Unit <span className="text-red-500">*</span>
+              </label>
+
+              {/* Coordinator: locked to their unit */}
+              {isCoordinator ? (
+                <>
+                  <input
+                    type="text"
+                    value={selectedUnit ? selectedUnit.name : ""}
+                    readOnly
+                    disabled
+                    className={inputStyles}
+                    placeholder="No eligible unit found for your email"
+                  />
+                  <p className="text-xs text-stone-500 mt-1">
+                    Your role is Club Coordinator. The unit is pre-selected and
+                    cannot be changed.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <input
+                    type="text"
+                    value={selectedUnit ? selectedUnit.name : unitSearchTerm}
+                    onChange={(e) => {
+                      setUnitSearchTerm(e.target.value);
+                      setIsUnitDropdownOpen(true);
+                      if (!e.target.value) handleInputChange("unit_id", "");
+                    }}
+                    onFocus={() => setIsUnitDropdownOpen(true)}
+                    placeholder="Search for unit"
+                    className={inputStyles}
+                  />
+                  {isUnitDropdownOpen && (
+                    <div className="absolute z-20 w-full mt-1 bg-white border border-stone-300 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                      {filteredUnits.length > 0 ? (
+                        filteredUnits.map((unit) => (
+                          <div
+                            key={unit._id}
+                            onClick={() => {
+                              handleInputChange("unit_id", unit._id);
+                              setUnitSearchTerm("");
+                              setIsUnitDropdownOpen(false);
+                            }}
+                            className="px-3 py-2 text-sm hover:bg-stone-100 cursor-pointer"
+                          >
+                            {unit.name}
+                          </div>
+                        ))
+                      ) : (
+                        <div className="px-3 py-2 text-sm text-stone-500">
+                          No units found.
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </>
+              )}
+
+              <ErrorMessage message={errors.unit_id} />
+            </div>
+
+            <div>
+              <label className={labelStyles}>
+                Position Type <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={formData.position_type}
+                onChange={(e) =>
+                  handleInputChange("position_type", e.target.value)
+                }
+                className={inputStyles}
+              >
+                <option value="">Select type</option>
+                {positionTypes.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+              <ErrorMessage message={errors.position_type} />
+            </div>
+
+            {formData.position_type === "Other" && (
+              <div>
+                <label className={labelStyles}>
+                  Custom Type <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.custom_position_type}
+                  onChange={(e) =>
+                    handleInputChange("custom_position_type", e.target.value)
+                  }
+                  placeholder="e.g., Research Assistant"
+                  className={inputStyles}
+                />
+                <ErrorMessage message={errors.custom_position_type} />
+              </div>
+            )}
+
+            <div>
+              <label className={labelStyles}>
+                Number of Positions <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="number"
+                min="1"
+                value={formData.position_count}
+                onChange={(e) =>
+                  handleInputChange("position_count", Number(e.target.value))
+                }
+                className={inputStyles}
+              />
+              <ErrorMessage message={errors.position_count} />
+            </div>
+
+            <div className="md:col-span-2">
+              <label className={labelStyles}>Description</label>
+              <textarea
+                value={formData.description}
+                onChange={(e) =>
+                  handleInputChange("description", e.target.value)
+                }
+                placeholder="Provide a detailed description of the position..."
+                rows={3}
+                className={inputStyles}
+              />
+            </div>
+          </div>
         </div>
 
         {/* Section 2: Responsibilities & Requirements */}
         <div className="pt-4 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6 border-t border-stone-200">
-            <DynamicFieldArray label="Responsibilities" array={formData.responsibilities} onUpdate={(index, value) => handleArrayChange("responsibilities", index, value)} onRemove={index => removeFromArray("responsibilities", index)} onAdd={() => addToArray("responsibilities")} error={errors.responsibilities}/>
-            
-            <div className="space-y-4">
-                 <DynamicFieldArray label="Required Skills" array={formData.requirements.skills_required} onUpdate={handleSkillsChange} onRemove={removeSkill} onAdd={addSkill} />
-                <div className="grid grid-cols-2 gap-4">
-                     <div>
-                        <label className={labelStyles}>Minimum CGPA</label>
-                        <input type="number" step="0.1" min="0" max="10" value={formData.requirements.min_cgpa} onChange={(e) => handleRequirementChange("min_cgpa", Number(e.target.value))} className={inputStyles} />
-                        <ErrorMessage message={errors.min_cgpa} />
-                    </div>
-                    <div>
-                        <label className={labelStyles}>Minimum Year</label>
-                        <select value={formData.requirements.min_year} onChange={(e) => handleRequirementChange("min_year", Number(e.target.value))} className={inputStyles}>
-                            {yearOptions.map((year) => (<option key={year.value} value={year.value}>{year.label}</option>))}
-                        </select>
-                    </div>
-                </div>
+          <DynamicFieldArray
+            label="Responsibilities"
+            array={formData.responsibilities}
+            onUpdate={(index, value) =>
+              handleArrayChange("responsibilities", index, value)
+            }
+            onRemove={(index) => removeFromArray("responsibilities", index)}
+            onAdd={() => addToArray("responsibilities")}
+            error={errors.responsibilities}
+          />
+
+          <div className="space-y-4">
+            <DynamicFieldArray
+              label="Required Skills"
+              array={formData.requirements.skills_required}
+              onUpdate={handleSkillsChange}
+              onRemove={removeSkill}
+              onAdd={addSkill}
+            />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className={labelStyles}>Minimum CGPA</label>
+                <input
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  max="10"
+                  value={formData.requirements.min_cgpa}
+                  onChange={(e) =>
+                    handleRequirementChange("min_cgpa", Number(e.target.value))
+                  }
+                  className={inputStyles}
+                />
+                <ErrorMessage message={errors.min_cgpa} />
+              </div>
+              <div>
+                <label className={labelStyles}>Minimum Year</label>
+                <select
+                  value={formData.requirements.min_year}
+                  onChange={(e) =>
+                    handleRequirementChange("min_year", Number(e.target.value))
+                  }
+                  className={inputStyles}
+                >
+                  {yearOptions.map((year) => (
+                    <option key={year.value} value={year.value}>
+                      {year.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
+          </div>
         </div>
 
         {/* Actions */}
         <div className="pt-5 flex flex-col sm:flex-row gap-4 border-t border-stone-200">
-          <button type="submit" disabled={isSubmitting} className="flex-1 bg-stone-800 text-white py-2.5 px-4 rounded-lg hover:bg-stone-700 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-stone-500 disabled:bg-stone-400 disabled:cursor-not-allowed">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="flex-1 bg-stone-800 text-white py-2.5 px-4 rounded-lg hover:bg-stone-700 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-stone-500 disabled:bg-stone-400 disabled:cursor-not-allowed"
+          >
             {isSubmitting ? "Creating..." : "Create Position"}
           </button>
-          <button type="button" onClick={() => navigate(-1)} className="flex-1 py-2.5 px-4 rounded-lg border border-stone-300 text-stone-700 hover:bg-stone-100 text-sm font-semibold transition-colors">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="flex-1 py-2.5 px-4 rounded-lg border border-stone-300 text-stone-700 hover:bg-stone-100 text-sm font-semibold transition-colors"
+          >
             Cancel
           </button>
         </div>


### PR DESCRIPTION
---
Name: Backend role-based scoping for Units + Coordinator UX alignment
Assignees: @harshitap1305 , @sakshi1755 
---

##  Related Issue
-   Closes #136 

---

##  Changes Introduced
-   **Added:** Server-side role-based scoping for GET /api/events/units.

     1. PRESIDENT → returns all organizational units.
     2. GENSEC_SCITECH/ACADEMIC/CULTURAL/SPORTS → returns units filtered by their council category (scitech, academic, cultural, sports).
     3. CLUB_COORDINATOR → returns only the coordinator’s unit, matched by contact_info.email == logged-in user email (case-insensitive).
     4. Default (e.g., STUDENT) → currently returns all units (unchanged). This can be restricted in a follow-up if desired.

-   **Updated:** Endpoint error handling and small code comments for clarity.
-   No DB schema changes, no new environment variables.

---

##  Why This Change?
-   **Problem:** The units endpoint returned all units regardless of the user's role. The frontend had to perform filtering, which was inconsistent and insecure.
-   **Solution:** Move the scoping logic to the backend so that responses are least-privilege by default and consistent across all clients.
-   **Impact:** This ensures safer data access. General Secretaries and Coordinators will now only see units relevant to them. The frontend logic remains compatible with the server-filtered data.

---

##  Screenshots
1. President's Dashboard: 
<img width="1157" height="901" alt="image" src="https://github.com/user-attachments/assets/57c441f3-43f3-41d7-bd94-04a7b50aecd8" />

2. Club Coordinator's Dashboard:
<img width="1380" height="896" alt="image" src="https://github.com/user-attachments/assets/c05e6e8a-71b5-4ac4-8016-89ad4edf88ac" />

3. GenSec's Dashboard:
<img width="1232" height="887" alt="image" src="https://github.com/user-attachments/assets/f460559e-678a-47c8-807e-0e31b66c71be" />


---

##  Testing
Manual role-by-role validation (user must be logged in; otherwise, expect a 401 error):

1.President

- Run: fetch('/api/events/units',{credentials:'include'}).then(r=>r.json())
- Expected: A full list of all organizational units.

2.GenSec (scitech/academic/cultural/sports)

- Run the same request as above.
- Expected: Every item returned should have a category that matches the GenSec’s council (e.g., 'scitech'). The expression data.every(u => u.category === 'scitech') should be true.

3. Club Coordinator

- Run the same request as above.
- Expected: Exactly one unit in the array, and its contact_info.email should match your login email (case-insensitive). If no email match is found in the database, expect an empty array [].

4. Unauthenticated

- Run the same request without a session.
- Expected: 401 Unauthorized error.

---

##  Documentation Updates
-   [ ] N/A

---

##  Checklist
-   [ ] I have created a new branch for this PR (`git checkout -b feature/role-based-scoping`).
-   [ ] I have starred the repository.
-   [ ] My code follows the project's coding style and conventions.
-   [ ] My commit messages are clear and follow the project's guidelines.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have added tests that prove my fix is effective or that my feature works.
-   [ ] All new and existing tests passed locally with my changes.
-   [ ] This PR introduces no breaking changes (or they are clearly documented).

---

##  Deployment Notes
-   N/A — no migrations, no new environment variables.

---

## 💬 Additional Notes
-   If the STUDENT role needs to be restricted (e.g., return [] or a 403 error), I can adjust the default branch in a follow-up PR.
